### PR TITLE
made guzzle version less strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "guzzle/guzzle": "3.9.*"
+        "guzzle/guzzle": ">=3.7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
if a project has dependencies for an other guzzle version (in my example for 3.7.x) because of an other vendor (f.e. aws/aws-sdk-php) there are unresolvable composer conflicts
