### PR TITLE
Allow overriding icon_url and icon_emoji

### DIFF
--- a/Slack/Client/Actions/ChatPostMessage.php
+++ b/Slack/Client/Actions/ChatPostMessage.php
@@ -58,9 +58,13 @@ class ChatPostMessage implements ActionsInterface
 
     private function parseIdentity()
     {
-        $this->parameter['username']   = $this->parameter['identity']->getUsername();
-        $this->parameter['icon_url']   = $this->parameter['identity']->getIconUrl();
-        $this->parameter['icon_emoji'] = $this->parameter['identity']->getIconEmoji();
+        $this->parameter['username'] = $this->parameter['identity']->getUsername();
+        if (empty($this->parameter['icon_url']) && $iconUrl = $this->parameter['identity']->getIconUrl()) {
+            $this->parameter['icon_url'] = $iconUrl;
+        }
+        if (empty($this->parameter['icon_emoji']) && $iconEmoji = $this->parameter['identity']->getIconEmoji()) {
+            $this->parameter['icon_emoji'] = $iconEmoji;
+        }
         unset($this->parameter['identity']);
     }
 


### PR DESCRIPTION
I want to send a message to a Slack channel with a custom `icon_url` parameter, but the way the identity parsing is currently set up that's impossible.

This patch takes care of not overriding `icon_url` nor `icon_emoji` if they're explicitly set in a `ChatPostMessage` request.