### PR TITLE
Fix composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,13 @@
         "exclude": ["/Tests"]
     },
     "require": {
-        "php": ">=5.4",
-        "symfony/symfony": "~2.3|~3.0",
-        "guzzle/guzzle": ">=3.7.0"
         "php": ">=5.6",
         "symfony/symfony": "~2.8|~3.0",
-        "guzzlehttp/guzzle": ">=6.0.0"
+        "guzzlehttp/guzzle": "^6.2.1"
     },
     "autoload": {
         "psr-0": { "DZunke\\SlackBundle": "" }
     },
-    "target-dir": "DZunke/SlackBundle"
     "target-dir": "DZunke/SlackBundle",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
dupes, missing commas and require at least Guzzle 6.2.1.

Before 6.2.1 has security issues and is blocked in [Roave/SecurityAdvisories](https://github.com/Roave/SecurityAdvisories/blob/d954a95c1be04118dbbda88f3524424695dd886f/composer.json#L37)

I'm not yet able to properly pull down the 2.0-dev branch to test, I think because of the composer.json issues.