### PR TITLE
#19 implement configuration to disable guzzle ssl verification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+SlackBundle v2.1.0
+==================
+- Add Support to disable SSL Verification at Guzzle Client
+
 SlackBundle v2.0.0
 ==================
 - (NOT BC) Feature: Upgrade to Guzzle 6 (thanks for Support @alister)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
                 ->info('The amount of retries for the connection if the Rate Limits of Slack are reached')
             ->end()
             ->booleanNode('verify_ssl')
-                ->defaultFalse()
+                ->defaultTrue()
             ->end()
         ->end();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,9 @@ class Configuration implements ConfigurationInterface
                 ->min(1)
                 ->info('The amount of retries for the connection if the Rate Limits of Slack are reached')
             ->end()
+            ->booleanNode('verify_ssl')
+                ->defaultFalse()
+            ->end()
         ->end();
 
         $rootNode->append($this->addIdentities());

--- a/DependencyInjection/DZunkeSlackExtension.php
+++ b/DependencyInjection/DZunkeSlackExtension.php
@@ -49,6 +49,7 @@ class DZunkeSlackExtension extends Extension
         $definition->addMethodCall('setEndpoint', [$config['endpoint']]);
         $definition->addMethodCall('setToken', [$config['token']]);
         $definition->addMethodCall('setLimitRetries', [$config['limit_retries']]);
+        $definition->addMethodCall('setVerifySsl', [$config['verify_ssl']]);
     }
 
 }

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -4,6 +4,7 @@
 d_zunke_slack:
     endpoint:             slack.com/api/
     token:                null # Required
+    verify_ssl:           true # ssl verification at guzzle client
 
     # The amount of retries for the connection if the Rate Limits of Slack are reached
     limit_retries:        3

--- a/Slack/Client.php
+++ b/Slack/Client.php
@@ -92,7 +92,7 @@ class Client
      */
     protected function executeRequest(Uri $uri)
     {
-        $guzzle = new GuzzleClient();
+        $guzzle = new GuzzleClient(['verify' => $this->connection->getVerifySsl()]);
 
         return $guzzle->request('GET', $uri);
     }

--- a/Slack/Client/Connection.php
+++ b/Slack/Client/Connection.php
@@ -20,6 +20,11 @@ class Connection
     protected $limitRetries = 3;
 
     /**
+     * @var bool
+     */
+    private $verifySsl = true;
+
+    /**
      * @param string $endpoint
      * @return $this
      */
@@ -74,6 +79,26 @@ class Connection
     public function getLimitRetries()
     {
         return $this->limitRetries;
+    }
+
+    /**
+     * @param bool $verifySsl
+     *
+     * @return $this
+     */
+    public function setVerifySsl($verifySsl)
+    {
+        $this->verifySsl = (bool) $verifySsl;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getVerifySsl()
+    {
+        return $this->verifySsl;
     }
 
     /**


### PR DESCRIPTION
The Connection-Class has been extended by the verifySsl option, it will be given to the guzzle client as Option "verify"