### PR TITLE
Resolve warnings when using public services

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -54,7 +54,6 @@ class Configuration implements ConfigurationInterface
         /** @var $connectionNode ArrayNodeDefinition */
         $microservicesNode = $node->requiresAtLeastOneElement()
             ->useAttributeAsKey('username')
-            ->cannotBeEmpty()
             ->info('Usernames to use for Communication inside the Messaging')
             ->prototype('array');
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -28,6 +28,18 @@ services:
         public: true
         arguments: ["@dz.slack.client"]
 
+    DZunke\SlackBundle\Slack\Messaging\IdentityBag: '@dz.slack.identity_bag'
+
+    DZunke\SlackBundle\Slack\Client\Connection: '@dz.slack.connection'
+
+    DZunke\SlackBundle\Slack\Client: '@dz.slack.client'
+
+    DZunke\SlackBundle\Slack\Messaging: '@dz.slack.messaging'
+
+    DZunke\SlackBundle\Slack\Channels: '@dz.slack.channels'
+
+    DZunke\SlackBundle\Slack\Users: '@dz.slack.users'
+
     DZunke\SlackBundle\Command\BotMessagingCommand:
         class: DZunke\SlackBundle\Command\BotMessagingCommand
         arguments: ["@dz.slack.channels", "@event_dispatcher"]


### PR DESCRIPTION
This pull request resolved warnings such as:

```
Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "dz.slack.messaging" service to "DZunke\SlackBundle\Slack\Messaging" instead.
```